### PR TITLE
Add credential rotation reminder workflow

### DIFF
--- a/.github/credential-rotations.yml
+++ b/.github/credential-rotations.yml
@@ -1,0 +1,55 @@
+# Credential Rotation Configuration
+#
+# The credential-rotation-reminder workflow checks this file daily and sends
+# notifications (GitHub issue, Jira ticket, email) when a credential is within
+# its remind_days_before window.
+#
+# After rotating a credential:
+#   1. Update the 'expires' date below to the new expiration
+#   2. Commit and push the change
+#   3. Close the corresponding GitHub issue and Jira ticket
+#
+# Required fields per credential: name, description, expires, rotation_steps
+# Optional fields (with defaults):
+#   remind_days_before: 15        — days before expiry to start reminding
+#   jira_priority: Highest        — Jira ticket priority
+#   notes: (none)                 — additional context shown in notifications
+
+email_to: tools@valideval.com
+email_from: tools@valideval.com
+jira_project: VEP
+
+credentials:
+  - name: CLAUDE_CODE_OAUTH_TOKEN
+    description: Claude Code CI/CD token for @claude on PRs across the Valid-Eval org
+    expires: "2027-01-29"
+    remind_days_before: 15
+    jira_priority: Highest
+    rotation_steps: |-
+      1. Run `claude setup-token` in a terminal (NOT inside Claude Code)
+      2. Update at https://github.com/organizations/Valid-Eval/settings/secrets/actions
+         - Find CLAUDE_CODE_OAUTH_TOKEN, click Update, paste new value
+         - Verify repo visibility includes all repos that need it (currently ve-app, ve-zarf)
+      3. Verify: trigger `@claude ping` on any open PR
+    notes: |-
+      - `claude setup-token` produces a long-lived CI/CD token
+      - Do NOT use the session token from ~/.claude/.credentials.json (expires in hours)
+      - Referenced as secrets.CLAUDE_CODE_OAUTH_TOKEN in workflows — no workflow changes needed on rotation
+
+  - name: JIRA_API_TOKEN
+    description: Atlassian API token for Jira REST API basic auth
+    expires: "2027-01-19"
+    remind_days_before: 15
+    jira_priority: Highest
+    rotation_steps: |-
+      1. Go to https://id.atlassian.com/manage-profile/security/api-tokens
+      2. Create a new API token (label it clearly, e.g. "ve-tools CI/CD Jan 2028")
+      3. Update at https://github.com/organizations/Valid-Eval/settings/secrets/actions
+         - Find JIRA_API_TOKEN, click Update, paste new value
+      4. Test: manually trigger a workflow that uses the Jira API, or trigger this
+         workflow via workflow_dispatch to verify the new token works
+    notes: |-
+      - Used with JIRA_USER_EMAIL for basic auth (email:token)
+      - The email secret does not need rotation — only the token
+      - If this token is already expired, the Jira notification step for OTHER
+        credentials will also fail — rotate this one first

--- a/.github/workflows/credential-rotation-reminder.yml
+++ b/.github/workflows/credential-rotation-reminder.yml
@@ -39,7 +39,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: pip install pyyaml
@@ -124,7 +124,7 @@ jobs:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: pip install pyyaml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Create notifications for due credentials
         if: steps.check.outputs.has_due == 'true' && (!inputs.dry_run || inputs.test_credential != '')
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CHECK_RESULT: ${{ steps.check.outputs.result }}
           JIRA_USER_EMAIL: ${{ vars.JIRA_USER_EMAIL }}

--- a/.github/workflows/credential-rotation-reminder.yml
+++ b/.github/workflows/credential-rotation-reminder.yml
@@ -1,0 +1,374 @@
+# Credential Rotation Reminders
+#
+# Checks .github/credential-rotations.yml daily for credentials approaching
+# expiration and sends notifications via GitHub issue, Jira ticket, and email.
+# Deduplicates by checking for existing open issues — each credential only
+# triggers one round of notifications until the issue is closed.
+#
+# Required org variable:
+#   JIRA_USER_EMAIL  — Atlassian account email (for basic auth)
+#
+# Required org secrets:
+#   JIRA_API_TOKEN   — https://id.atlassian.com/manage-profile/security/api-tokens
+#   SG_API_KEY       — SendGrid API key
+
+name: Credential Rotation Reminders
+
+on:
+  schedule:
+    - cron: "0 9 * * *"   # Daily at 9 AM UTC
+  pull_request:
+    paths:
+      - .github/credential-rotations.yml
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Log due credentials without creating tickets or sending email"
+        type: boolean
+        default: false
+      test_credential:
+        description: "Send a real test notification for a synthetic credential (e.g. TEST_CREDENTIAL)"
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Validate credential-rotations.yml
+        run: |
+          python3 << 'PYEOF'
+          import re, sys, datetime, yaml
+
+          CONFIG_PATH = '.github/credential-rotations.yml'
+          errors = []
+
+          # --- Parse YAML ---
+          try:
+              with open(CONFIG_PATH) as f:
+                  config = yaml.safe_load(f)
+          except yaml.YAMLError as e:
+              print(f"FATAL: {CONFIG_PATH} is not valid YAML:\n{e}")
+              sys.exit(1)
+
+          if not isinstance(config, dict):
+              print(f"FATAL: {CONFIG_PATH} must contain a YAML mapping, got {type(config).__name__}")
+              sys.exit(1)
+
+          # --- Top-level fields ---
+          for field in ('email_to', 'email_from', 'jira_project'):
+              if not config.get(field):
+                  errors.append(f"Missing top-level field: '{field}'")
+
+          if not isinstance(config.get('credentials'), list) or len(config['credentials']) == 0:
+              errors.append("'credentials' must be a non-empty list")
+              # Can't continue without credentials
+              for e in errors:
+                  print(f"ERROR: {e}")
+              sys.exit(1)
+
+          # --- Per-credential validation ---
+          required_fields = ('name', 'description', 'expires', 'rotation_steps')
+          today = datetime.date.today()
+
+          for i, cred in enumerate(config['credentials']):
+              label = cred.get('name', f'credentials[{i}]')
+
+              for field in required_fields:
+                  if not cred.get(field):
+                      errors.append(f"{label}: missing required field '{field}'")
+
+              # Validate name contains only safe characters
+              name = cred.get('name', '')
+              if name and not re.match(r'^[A-Za-z0-9_-]+$', name):
+                  errors.append(f"credentials[{i}]: 'name' must contain only alphanumeric characters, hyphens, and underscores (got '{name}')")
+
+              # Validate expires is a parseable ISO date
+              expires_raw = cred.get('expires', '')
+              try:
+                  expires = datetime.date.fromisoformat(str(expires_raw))
+                  days_left = (expires - today).days
+                  if days_left < 0:
+                      print(f"WARNING: {label} expired {abs(days_left)} days ago ({expires_raw})")
+                  else:
+                      print(f"OK: {label} — expires {expires_raw} ({days_left} days from now)")
+              except (ValueError, TypeError):
+                  errors.append(f"{label}: 'expires' value '{expires_raw}' is not a valid ISO date (expected YYYY-MM-DD)")
+
+              # Validate remind_days_before is a positive integer if present
+              rdb = cred.get('remind_days_before')
+              if rdb is not None:
+                  if not isinstance(rdb, int) or rdb <= 0:
+                      errors.append(f"{label}: 'remind_days_before' must be a positive integer (got '{rdb}')")
+
+          if errors:
+              print(f"\n{len(errors)} validation error(s):")
+              for e in errors:
+                  print(f"  ERROR: {e}")
+              sys.exit(1)
+          else:
+              print(f"\nAll {len(config['credentials'])} credential(s) validated successfully")
+          PYEOF
+
+  check-and-notify:
+    needs: validate
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Find credentials due for rotation
+        id: check
+        env:
+          TEST_CREDENTIAL: ${{ inputs.test_credential }}
+        run: |
+          python3 << 'PYEOF'
+          import json, datetime, os, uuid, yaml
+
+          with open('.github/credential-rotations.yml') as f:
+              config = yaml.safe_load(f)
+
+          today = datetime.date.today()
+          due = []
+
+          test_name = os.environ.get('TEST_CREDENTIAL', '').strip()
+          if test_name:
+              # Synthetic test credential — bypasses expiration check
+              due.append({
+                  'name': test_name,
+                  'description': f'Integration test for credential rotation notifications',
+                  'expires': today.isoformat(),
+                  'days_left': 0,
+                  'remind_days_before': 15,
+                  'jira_priority': 'Lowest',
+                  'rotation_steps': '1. This is a test notification — no action required\n2. Close the GitHub issue and Jira ticket when done testing',
+                  'notes': 'Generated by workflow_dispatch with test_credential input',
+                  'is_test': True,
+              })
+              print(f"Test mode: sending notifications for synthetic credential '{test_name}'")
+          else:
+              for cred in config['credentials']:
+                  expires = datetime.date.fromisoformat(cred['expires'])
+                  days_left = (expires - today).days
+                  if days_left <= cred.get('remind_days_before', 15):
+                      cred['days_left'] = days_left
+                      due.append(cred)
+
+          output = {
+              'due': due,
+              'email_to': config.get('email_to', ''),
+              'email_from': config.get('email_from', ''),
+              'jira_project': config.get('jira_project', 'VEP'),
+          }
+
+          delimiter = f"ghadelimiter_{uuid.uuid4()}"
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f"result<<{delimiter}\n")
+              f.write(json.dumps(output))
+              f.write(f"\n{delimiter}\n")
+              f.write(f"has_due={'true' if due else 'false'}\n")
+
+          if due and not test_name:
+              print(f"{len(due)} credential(s) due for rotation:")
+              for c in due:
+                  status = f"EXPIRED ({abs(c['days_left'])} days ago)" if c['days_left'] < 0 else f"{c['days_left']} days left"
+                  print(f"  - {c['name']}: {status}")
+          elif not due:
+              print("No credentials due for rotation")
+          PYEOF
+
+      - name: Create notifications for due credentials
+        if: steps.check.outputs.has_due == 'true' && (!inputs.dry_run || inputs.test_credential != '')
+        uses: actions/github-script@v7
+        env:
+          CHECK_RESULT: ${{ steps.check.outputs.result }}
+          JIRA_USER_EMAIL: ${{ vars.JIRA_USER_EMAIL }}
+          JIRA_API_TOKEN: ${{ secrets.JIRA_API_TOKEN }}
+          SG_API_KEY: ${{ secrets.SG_API_KEY }}
+        with:
+          script: |
+            const result = JSON.parse(process.env.CHECK_RESULT);
+            const { due, email_to, email_from, jira_project } = result;
+
+            // Ensure 'maintenance' label exists
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'maintenance',
+              });
+            } catch {
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: 'maintenance',
+                color: '0e8a16',
+                description: 'Maintenance and operational tasks',
+              });
+            }
+
+            for (const cred of due) {
+              const titlePrefix = cred.is_test ? '[TEST] ' : '';
+              const issueTitle = `${titlePrefix}Rotate credential: ${cred.name}`;
+              const issueLabels = cred.is_test ? ['maintenance', 'test'] : ['maintenance'];
+
+              // --- Dedup: skip if open issue already exists (unless test credential) ---
+              if (!cred.is_test) {
+                const search = await github.rest.search.issuesAndPullRequests({
+                  q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "Rotate credential: ${cred.name}" label:maintenance`,
+                });
+                if (search.data.total_count > 0) {
+                  console.log(`Skipping ${cred.name} — open issue #${search.data.items[0].number} exists`);
+                  continue;
+                }
+              }
+
+              const urgency = cred.days_left <= 0
+                ? `**EXPIRED** (${Math.abs(cred.days_left)} days ago)`
+                : `**${cred.days_left} days** until expiry`;
+
+              // --- GitHub Issue ---
+              const issueBody = [
+                `## Credential Rotation: \`${cred.name}\``,
+                '',
+                cred.description,
+                '',
+                `**Status:** ${urgency} (expires ${cred.expires})`,
+                '',
+                '### Rotation Steps',
+                '',
+                cred.rotation_steps,
+                '',
+                '### Notes',
+                '',
+                cred.notes || 'None',
+                '',
+                '---',
+                '*After rotating, update the `expires` date in `.github/credential-rotations.yml`, commit, and close this issue.*',
+              ].join('\n');
+
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: issueTitle,
+                labels: issueLabels,
+                body: issueBody,
+              });
+              console.log(`Created GitHub issue #${issue.data.number} for ${cred.name}`);
+
+              // --- Jira Ticket ---
+              if (process.env.JIRA_USER_EMAIL && process.env.JIRA_API_TOKEN) {
+                try {
+                  const jiraAuth = Buffer.from(
+                    `${process.env.JIRA_USER_EMAIL}:${process.env.JIRA_API_TOKEN}`
+                  ).toString('base64');
+
+                  const statusText = cred.days_left <= 0
+                    ? `EXPIRED (${Math.abs(cred.days_left)} days ago)`
+                    : `${cred.days_left} days until expiry`;
+
+                  const jiraDesc = [
+                    cred.description,
+                    '',
+                    `Expires: ${cred.expires} (${statusText})`,
+                    '',
+                    '*Rotation steps:*',
+                    cred.rotation_steps.split('\n').map(line => {
+                      // Convert markdown numbered list to Jira wiki syntax
+                      const m = line.match(/^(\d+)\.\s+(.*)/);
+                      return m ? `# ${m[2]}` : line;
+                    }).join('\n'),
+                    '',
+                    'After rotating, update the expires date in .github/credential-rotations.yml in the ve-tools repo and close this ticket.',
+                  ].join('\n');
+
+                  const jiraRes = await fetch('https://valideval.atlassian.net/rest/api/2/issue', {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      'Authorization': `Basic ${jiraAuth}`,
+                    },
+                    body: JSON.stringify({
+                      fields: {
+                        project: { key: jira_project },
+                        issuetype: { name: 'Task' },
+                        priority: { name: cred.jira_priority || 'Highest' },
+                        summary: `${titlePrefix}Rotate credential: ${cred.name}`,
+                        description: jiraDesc,
+                      },
+                    }),
+                  });
+
+                  if (jiraRes.ok) {
+                    const jiraData = await jiraRes.json();
+                    console.log(`Created Jira ticket ${jiraData.key} for ${cred.name}`);
+                  } else {
+                    const errText = await jiraRes.text();
+                    console.error(`Jira API error for ${cred.name}: ${jiraRes.status} ${errText}`);
+                  }
+                } catch (e) {
+                  console.error(`Jira error for ${cred.name}: ${e.message}`);
+                }
+              } else {
+                console.log('Skipping Jira — JIRA_USER_EMAIL or JIRA_API_TOKEN not configured');
+              }
+
+              // --- Email via SendGrid ---
+              if (process.env.SG_API_KEY && email_to) {
+                try {
+                  const statusText = cred.days_left <= 0
+                    ? `EXPIRED (${Math.abs(cred.days_left)} days ago)`
+                    : `${cred.days_left} days until expiry`;
+
+                  const emailBody = [
+                    cred.description,
+                    '',
+                    `Status: ${statusText} (expires ${cred.expires})`,
+                    '',
+                    'Rotation Steps:',
+                    cred.rotation_steps,
+                    '',
+                    cred.notes ? `Notes:\n${cred.notes}` : '',
+                    '',
+                    'After rotating, update the expires date in .github/credential-rotations.yml in the ve-tools repo.',
+                  ].join('\n');
+
+                  const sgRes = await fetch('https://api.sendgrid.com/v3/mail/send', {
+                    method: 'POST',
+                    headers: {
+                      'Authorization': `Bearer ${process.env.SG_API_KEY}`,
+                      'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({
+                      personalizations: [{ to: [{ email: email_to }] }],
+                      from: { email: email_from || email_to, name: 'Valid Eval Maintenance' },
+                      subject: `[Action Required] ${titlePrefix}Rotate credential: ${cred.name}`,
+                      content: [{ type: 'text/plain', value: emailBody }],
+                    }),
+                  });
+
+                  if (sgRes.ok || sgRes.status === 202) {
+                    console.log(`Sent email to ${email_to} for ${cred.name}`);
+                  } else {
+                    const errText = await sgRes.text();
+                    console.error(`SendGrid error for ${cred.name}: ${sgRes.status} ${errText}`);
+                  }
+                } catch (e) {
+                  console.error(`SendGrid error for ${cred.name}: ${e.message}`);
+                }
+              } else {
+                console.log('Skipping email — SG_API_KEY or email_to not configured');
+              }
+            }


### PR DESCRIPTION
## Summary

- Adds a config-driven credential rotation reminder system that checks `.github/credential-rotations.yml` daily for credentials approaching expiration
- Sends notifications via 3 channels: GitHub issue, Jira ticket (VEP/Highest), and email (tools@valideval.com)
- Deduplicates by searching for existing open issues — each credential triggers one notification round until the issue is closed
- Currently tracks `CLAUDE_CODE_OAUTH_TOKEN` (expires 2027-01-29) and `JIRA_API_TOKEN` (expires 2027-01-19)
- Adding new credentials requires only a new entry in the YAML config file

### Workflow modes
- **Daily schedule** — checks all credentials against their `remind_days_before` window
- **PR validation** — runs the `validate` job when `.github/credential-rotations.yml` is modified
- **`dry_run`** — logs which credentials are due without creating notifications
- **`test_credential`** — sends real `[TEST]`-prefixed notifications to verify all integrations

### Required org secrets/variables
- `JIRA_USER_EMAIL` — org variable (created)
- `JIRA_API_TOKEN` — org secret (created)
- `SG_API_KEY` — org secret (already existed)

## Test plan
- [ ] Validate job passes on this PR (automatic — triggered by `.github/credential-rotations.yml` change)
- [ ] After merge: trigger `workflow_dispatch` with `dry_run` checked — verify no credentials are flagged as due
- [ ] After merge: trigger `workflow_dispatch` with `test_credential: TEST_CREDENTIAL` — verify GitHub issue, Jira ticket, and email are all created
- [ ] Clean up test artifacts (close test issue, close test Jira ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)