### PR TITLE
Add automated code review workflows (Claude, Gemini, agent reviewers)

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,12 @@
+# Gemini Code Assist configuration for ve-tools.
+# Pattern: matches ve-app and ve-zarf repos.
+# Gemini posts line-level review comments on PRs automatically.
+pull_request_opened:
+  summary: true
+  code_review: true
+  include_drafts: false
+
+ignore_patterns:
+  - "scratch/**"
+  - "*.pyc"
+  - "__pycache__/**"

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -2,15 +2,7 @@
 
 ## Project Context
 
-ve-tools is a mixed-language repository containing operational tooling and compliance data
-for the Valid Eval platform. It includes Python CLI tools, a Go binary, GitHub Actions
-workflows, YAML compliance data, and markdown documentation.
-
-For full project context, read these files in order of priority:
-
-1. **`CLAUDE.md`** — Repository structure, commands, environment context, cross-repo references
-2. **`compliance/DESIGN.md`** — Compliance OS architecture, data model, and vision
-3. **`compliance/ssp-review-findings.md`** — Authoritative SSP findings list
+For full project context, read `CLAUDE.md` — repository structure, commands, environment context, and cross-repo references.
 
 ## Tech Stack — Avoid Common False Positives
 
@@ -22,7 +14,7 @@ For full project context, read these files in order of priority:
   (Inspector2, Grype, Dependabot). Only structural/schema issues are reviewable — content
   accuracy is a human responsibility.
 - **GitHub Actions**: Credential rotation workflow uses org-level secrets (`JIRA_API_TOKEN`,
-  `SG_API_KEY`). These are intentional and documented.
+  `SG_API_KEY`).
 
 ## What to Focus On
 

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,43 @@
+# ve-tools Code Review Guidelines
+
+## Project Context
+
+ve-tools is a mixed-language repository containing operational tooling and compliance data
+for the Valid Eval platform. It includes Python CLI tools, a Go binary, GitHub Actions
+workflows, YAML compliance data, and markdown documentation.
+
+For full project context, read these files in order of priority:
+
+1. **`CLAUDE.md`** — Repository structure, commands, environment context, cross-repo references
+2. **`compliance/DESIGN.md`** — Compliance OS architecture, data model, and vision
+3. **`compliance/ssp-review-findings.md`** — Authoritative SSP findings list
+
+## Tech Stack — Avoid Common False Positives
+
+- **credbridge (Go)**: AWS ECR credential bridging binary built into every VE container image.
+  The `replace` directive in `go.mod` is intentional — `credbridge/` is a local sub-module.
+- **vetools (Python)**: Click-based CLI with kubernetes-client and PyRSMQ dependencies.
+  Installed as kubectl plugins (`kubectl ve-console`, `kubectl ve-queues`, etc.).
+- **Compliance YAML**: Human-authored decision records. Scanner data stays in source systems
+  (Inspector2, Grype, Dependabot). Only structural/schema issues are reviewable — content
+  accuracy is a human responsibility.
+- **GitHub Actions**: Credential rotation workflow uses org-level secrets (`JIRA_API_TOKEN`,
+  `SG_API_KEY`). These are intentional and documented.
+
+## What to Focus On
+
+- Logic errors and correctness bugs in Python and Go code
+- YAML schema consistency and cross-reference integrity in compliance data
+- GitHub Actions workflow correctness (action versions, permissions, secret references)
+- Go module dependency issues (go.mod/go.sum consistency)
+- Breaking changes to credbridge (affects all VE container images downstream)
+- Markdown cross-reference integrity
+
+## What NOT to Flag
+
+- Pre-existing code not changed in the PR
+- The `replace` directive in `go.mod` (intentional local sub-module pattern)
+- Hardcoded AWS GovCloud regions or account IDs in compliance docs (intentional)
+- Compliance YAML content accuracy (humans own compliance decisions)
+- Style, formatting, or naming suggestions
+- Org-level secret references (`JIRA_API_TOKEN`, `SG_API_KEY`, `CLAUDE_CODE_OAUTH_TOKEN`)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,10 +52,10 @@ jobs:
             ## Before You Start
 
             1. Read existing review comments and their reply threads:
-               gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments --paginate --jq '.[] | {id, path, line, body: (.body | split("\n")[0]), in_reply_to_id}'
-               gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews --paginate --jq '.[] | {user: .user.login, state, body: (.body // "" | split("\n")[0])}'
+               gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments --paginate --jq '.[] | {id, path, line, body: (.body | split("\n")[0]), in_reply_to_id}'
+               gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --paginate --jq '.[] | {user: .user.login, state, body: (.body // "" | split("\n")[0])}'
             2. Check review thread states to see which comments have been resolved or replied to:
-               gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { pullRequest(number: ${PR_NUMBER}) { reviewThreads(first: 100) { nodes { isResolved, comments(first: 10) { nodes { body, author { login } } } } } } } }'
+               gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { pullRequest(number: ${{ github.event.pull_request.number }}) { reviewThreads(first: 100) { nodes { isResolved, comments(first: 10) { nodes { body, author { login } } } } } } } }'
             3. For resolved threads or threads with developer replies:
                - If the developer fixed the issue: do not re-flag it
                - If the developer replied explaining why they chose not to address it: respect that decision
@@ -116,7 +116,7 @@ jobs:
 
             Submit a pull request review using the GitHub API:
 
-            gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews --input /tmp/review.json
+            gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/reviews --input /tmp/review.json
 
             Where /tmp/review.json contains a JSON object with event "COMMENT", a body for the summary,
             and a comments array with objects containing path, line, and body fields.
@@ -126,7 +126,7 @@ jobs:
             - What's wrong with evidence (trace the data flow, show the actual values)
             - Suggested fix (concrete, not vague)
 
-            The line field must reference a line number visible in the diff. Use gh pr diff ${PR_NUMBER} to verify line numbers.
+            The line field must reference a line number visible in the diff. Use gh pr diff ${{ github.event.pull_request.number }} to verify line numbers.
 
             If no new issues are found, submit a review with an empty comments array and a body stating no issues found.
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -78,12 +78,6 @@ jobs:
             - Error handling gaps in credential bridging flow
             - Go module dependency issues (go.mod/go.sum inconsistencies)
 
-            Compliance YAML (compliance/):
-            - Schema inconsistencies (mismatched field names across files)
-            - Invalid cross-references (finding IDs, commitment IDs that don't exist)
-            - Calendar date errors (impossible dates, wrong recurrence patterns)
-            - YAML syntax errors or structural problems
-
             GitHub Actions workflows (.github/):
             - Incorrect action versions or missing pinning
             - Secret reference errors (referencing secrets that don't exist)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
+        continue-on-error: true  # action skips with non-zero exit when workflow file differs from default branch (security policy)
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,20 +12,19 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: read
-      id-token: write
+      id-token: write  # required by anthropics/claude-code-action for Anthropic API authentication
       actions: read
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Run Claude Code Review
         id: claude-review
         continue-on-error: true  # action skips with non-zero exit when workflow file differs from default branch (security policy)
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,142 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  claude-review:
+    if: github.event.pull_request.user.login != 'renovate[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          additional_permissions: |
+            actions: read
+
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+            EVENT: ${{ github.event.action }}
+            BEFORE_SHA: ${{ github.event.before }}
+            AFTER_SHA: ${{ github.event.after }}
+            BASE_BRANCH: ${{ github.event.pull_request.base.ref }}
+
+            ## Review Scope
+
+            You are reviewing a pull request in a mixed-language operational tooling and compliance data repository.
+            This repo contains: Python CLI tools (vetools package, kubectl plugins), Go code (credbridge for ECR
+            credential bridging), GitHub Actions workflows, YAML compliance data, and markdown documentation.
+
+            - If EVENT is "opened": Review the full PR diff using `git diff origin/${BASE_BRANCH}...HEAD`
+            - If EVENT is "synchronize": Review ONLY the newly pushed changes using `git diff ${BEFORE_SHA}..${AFTER_SHA}`. Do NOT re-review code from earlier commits that hasn't changed.
+
+            ## Before You Start
+
+            1. Read existing review comments and their reply threads:
+               gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/comments --paginate --jq '.[] | {id, path, line, body: (.body | split("\n")[0]), in_reply_to_id}'
+               gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews --paginate --jq '.[] | {user: .user.login, state, body: (.body // "" | split("\n")[0])}'
+            2. Check review thread states to see which comments have been resolved or replied to:
+               gh api graphql -f query='{ repository(owner: "${{ github.repository_owner }}", name: "${{ github.event.repository.name }}") { pullRequest(number: ${PR_NUMBER}) { reviewThreads(first: 100) { nodes { isResolved, comments(first: 10) { nodes { body, author { login } } } } } } } }'
+            3. For resolved threads or threads with developer replies:
+               - If the developer fixed the issue: do not re-flag it
+               - If the developer replied explaining why they chose not to address it: respect that decision
+               - If the code was changed but the fix looks incomplete: you may comment noting the remaining concern
+            4. Do NOT repeat any finding that has already been reported — even if it's still unfixed and unresolved
+
+            ## What to Look For
+
+            Focus on actionable bugs and correctness issues in the changed code:
+
+            Python (vetools package, kubectl plugins):
+            - Click CLI argument/option misconfigurations
+            - Kubernetes client API misuse (wrong resource types, missing error handling)
+            - PyRSMQ message format errors
+            - Import errors or missing dependencies in setup.py/requirements.txt
+
+            Go (credbridge):
+            - AWS SDK credential chain errors (wrong provider order, missing region config)
+            - ECR token handling bugs (expiration, encoding, registry URL parsing)
+            - Error handling gaps in credential bridging flow
+            - Go module dependency issues (go.mod/go.sum inconsistencies)
+
+            Compliance YAML (compliance/):
+            - Schema inconsistencies (mismatched field names across files)
+            - Invalid cross-references (finding IDs, commitment IDs that don't exist)
+            - Calendar date errors (impossible dates, wrong recurrence patterns)
+            - YAML syntax errors or structural problems
+
+            GitHub Actions workflows (.github/):
+            - Incorrect action versions or missing pinning
+            - Secret reference errors (referencing secrets that don't exist)
+            - Missing or overly broad permissions
+            - credential-rotations.yml: invalid date formats, missing required fields
+
+            Markdown documentation:
+            - Cross-reference integrity (links to files that don't exist)
+            - Factual accuracy of compliance claims against known data
+
+            General:
+            - Logic errors, wrong conditions, missing edge cases
+            - Breaking changes to credbridge (built into every VE container image)
+            - Data flow bugs
+
+            ## What NOT to Flag
+
+            - Pre-existing code that was not changed in this push
+            - Style, formatting, naming, or documentation suggestions
+            - Theoretical performance concerns
+            - Compliance YAML content accuracy (humans own compliance decisions — only flag structural/schema issues)
+            - The replace directive in go.mod (credbridge is intentionally a local sub-module)
+            - Hardcoded AWS GovCloud regions or account references in compliance docs (intentional)
+            - Org-level secret references (JIRA_API_TOKEN, SG_API_KEY, CLAUDE_CODE_OAUTH_TOKEN)
+
+            ## Output Format
+
+            Post line-specific findings as inline review comments on the relevant lines of the diff.
+            For concerns that are genuinely about the overall PR, use the review body summary instead.
+
+            Submit a pull request review using the GitHub API:
+
+            gh api repos/${{ github.repository }}/pulls/${PR_NUMBER}/reviews --input /tmp/review.json
+
+            Where /tmp/review.json contains a JSON object with event "COMMENT", a body for the summary,
+            and a comments array with objects containing path, line, and body fields.
+
+            Each inline comment should include:
+            - Severity prefix: [Critical] (blocks merge), [Warning] (should fix), or [Note] (consider)
+            - What's wrong with evidence (trace the data flow, show the actual values)
+            - Suggested fix (concrete, not vague)
+
+            The line field must reference a line number visible in the diff. Use gh pr diff ${PR_NUMBER} to verify line numbers.
+
+            If no new issues are found, submit a review with an empty comments array and a body stating no issues found.
+
+            ## Scope Override
+
+            The review scope and "What NOT to Flag" guidelines above are defaults for automated per-push reviews.
+            If a developer explicitly requests a comprehensive or expanded review, follow their instructions and expand
+            your scope accordingly. Developer requests always take precedence over these defaults.
+
+            For project context, read these files as needed:
+            - CLAUDE.md — Repository structure, commands, environment context, cross-repo references
+            - compliance/DESIGN.md — Compliance OS architecture and data model
+
+          claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(git diff:*),Bash(git log:*),Bash(gh api:*)"'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -46,8 +46,8 @@ jobs:
             This repo contains: Python CLI tools (vetools package, kubectl plugins), Go code (credbridge for ECR
             credential bridging), GitHub Actions workflows, YAML compliance data, and markdown documentation.
 
-            - If EVENT is "opened": Review the full PR diff using `git diff origin/${BASE_BRANCH}...HEAD`
-            - If EVENT is "synchronize": Review ONLY the newly pushed changes using `git diff ${BEFORE_SHA}..${AFTER_SHA}`. Do NOT re-review code from earlier commits that hasn't changed.
+            - If EVENT is "opened": Review the full PR diff using `git diff origin/${{ github.event.pull_request.base.ref }}...HEAD`
+            - If EVENT is "synchronize": Review ONLY the newly pushed changes using `git diff ${{ github.event.before }}..${{ github.event.after }}`. Do NOT re-review code from earlier commits that hasn't changed.
 
             ## Before You Start
 
@@ -136,8 +136,6 @@ jobs:
             If a developer explicitly requests a comprehensive or expanded review, follow their instructions and expand
             your scope accordingly. Developer requests always take precedence over these defaults.
 
-            For project context, read these files as needed:
-            - CLAUDE.md — Repository structure, commands, environment context, cross-repo references
-            - compliance/DESIGN.md — Compliance OS architecture and data model
+            For project context, read `CLAUDE.md` — repository structure, commands, environment context, and cross-repo references.
 
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(git diff:*),Bash(git log:*),Bash(gh api:*)"'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,41 @@
+# Interactive Claude Code assistant — triggered by @claude mentions in issues/PRs.
+# Pattern: identical to ve-app, ve-zarf, ve-iac, infosec-iac repos.
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,17 +24,17 @@ jobs:
       contents: read
       pull-requests: read
       issues: read
-      id-token: write
-      actions: read
+      id-token: write  # required by anthropics/claude-code-action for Anthropic API authentication
+      actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1.0.102
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           additional_permissions: |

--- a/AGENT-REVIEWERS.md
+++ b/AGENT-REVIEWERS.md
@@ -83,5 +83,5 @@ You are a reviewer focused on GitHub Actions workflow correctness and security.
 - Credential rotation entries have invalid date formats
 
 **Do NOT flag:**
-- Standard VE org secrets: `CLAUDE_CODE_OAUTH_TOKEN`, `JIRA_API_TOKEN`, `SG_API_KEY`
+- Standard VE org secrets: CLAUDE_CODE_OAUTH_TOKEN, JIRA_API_TOKEN, SG_API_KEY, GITHUB_TOKEN
 - Style preferences in YAML formatting

--- a/AGENT-REVIEWERS.md
+++ b/AGENT-REVIEWERS.md
@@ -45,7 +45,7 @@ You are a reviewer focused on the Go credbridge binary and its integration point
 - Error handling is missing for AWS API calls that can fail
 
 **Do NOT flag:**
-- The `replace` directive in `go.mod` (intentional local sub-module)
+- The existence of the `replace` directive in `go.mod` (intentional local sub-module pattern) — but DO flag if the module path in the directive mismatches the sub-module's declared module name in its own `go.mod`
 - GovCloud-specific region hardcoding (intentional)
 - Style or formatting preferences
 

--- a/AGENT-REVIEWERS.md
+++ b/AGENT-REVIEWERS.md
@@ -58,8 +58,8 @@ You are a reviewer focused on GitHub Actions workflow correctness and security.
 **What to check:**
 
 1. **Action versions**:
-   - Actions use specific versions (not `@main` or `@latest`)
-   - Version references are consistent across workflows
+   - Actions are pinned to commit SHAs with a version comment (e.g., `@abc123 # v1.2.3`) — this is the VE standard; floating tags like `@v1`, `@main`, or `@latest` are not acceptable
+   - SHA pins are consistent across workflows (same action should use the same SHA everywhere)
 
 2. **Secrets and permissions**:
    - Referenced secrets exist at org or repo level
@@ -77,7 +77,7 @@ You are a reviewer focused on GitHub Actions workflow correctness and security.
    - Expiry dates are in the future (or flagged as overdue)
 
 **Flag issues if:**
-- An action version is unpinned or uses a mutable tag
+- An action uses a floating tag (`@v1`, `@main`, `@latest`) instead of a pinned SHA
 - Permissions are broader than necessary
 - Secret references don't match documented org secrets
 - Credential rotation entries have invalid date formats

--- a/AGENT-REVIEWERS.md
+++ b/AGENT-REVIEWERS.md
@@ -14,41 +14,6 @@ This is a mixed-language operational tooling and compliance data repository. Whe
 
 # Agents
 
-## schema-reviewer
-
-You are a reviewer focused on YAML schema consistency and cross-reference integrity in the compliance data files.
-
-**Your focus:** Verify that compliance YAML files maintain consistent schemas and valid cross-references.
-
-**What to check:**
-
-1. **Schema consistency** across `compliance/decisions/*.yaml`:
-   - All entries in a file use the same field names and structure
-   - Required fields are present (id, status, description at minimum)
-   - Date fields use consistent format (YYYY-MM-DD)
-   - Status values are from a consistent set (not mixing "open"/"active"/"pending" arbitrarily)
-
-2. **Cross-references** between compliance files:
-   - Finding IDs referenced in decisions match entries in `ssp-review-findings.md`
-   - Calendar entries reference valid obligation sources
-   - Delegation tracker references valid party names consistently
-
-3. **Calendar accuracy** in `compliance/calendar/recurring.yaml`:
-   - Recurrence patterns are valid (monthly, quarterly, annual, etc.)
-   - No impossible dates (Feb 30, etc.)
-   - Frequency and description are consistent
-
-**Flag issues if:**
-- A YAML file has entries with inconsistent field names (e.g., some use `finding_id`, others use `findingId`)
-- A cross-reference points to an ID that doesn't exist in the target file
-- Calendar dates are invalid or recurrence patterns are malformed
-- Required fields are missing from new entries
-
-**Do NOT flag:**
-- Content accuracy of compliance decisions (humans own those decisions)
-- Style preferences in YAML formatting or field ordering
-- Pre-existing schema inconsistencies not introduced by this PR
-
 ## credbridge-reviewer
 
 You are a reviewer focused on the Go credbridge binary and its integration points.

--- a/AGENT-REVIEWERS.md
+++ b/AGENT-REVIEWERS.md
@@ -79,10 +79,9 @@ You are a reviewer focused on GitHub Actions workflow correctness and security.
 **Flag issues if:**
 - An action uses a floating tag (`@v1`, `@main`, `@latest`) instead of a pinned SHA
 - Permissions are broader than necessary
-- Secret references don't match documented org secrets
+- A referenced secret is not one of the standard VE org secrets listed below
 - Credential rotation entries have invalid date formats
 
 **Do NOT flag:**
-- The use of `CLAUDE_CODE_OAUTH_TOKEN` secret (standard across all VE repos)
-- Org-level secrets like `JIRA_API_TOKEN` and `SG_API_KEY` (documented in CLAUDE.md)
+- Standard VE org secrets: `CLAUDE_CODE_OAUTH_TOKEN`, `JIRA_API_TOKEN`, `SG_API_KEY`
 - Style preferences in YAML formatting

--- a/AGENT-REVIEWERS.md
+++ b/AGENT-REVIEWERS.md
@@ -1,0 +1,127 @@
+# Guidelines
+
+This is a mixed-language operational tooling and compliance data repository. When reviewing PRs:
+
+- Python code (`vetools/`, `bin/`) uses Click for CLI and kubernetes-client for K8s interaction
+- Go code (`credbridge/`) provides ECR credential bridging built into every VE container image
+- Compliance YAML (`compliance/`) stores human decisions — scanner data stays in source systems
+- GitHub Actions workflows handle credential rotation reminders and code review automation
+- The `replace` directive in `go.mod` is intentional — `credbridge/` is a local sub-module
+- Hardcoded AWS GovCloud regions and account IDs in compliance docs are intentional
+
+# Context
+
+- **CLAUDE.md** — Repository structure, commands, environment context, cross-repo references
+- **compliance/DESIGN.md** — Compliance OS architecture, data model, and vision
+- **compliance/ssp-review-findings.md** — Authoritative SSP findings list (264 findings, 9 themes)
+- **compliance/calendar/recurring.yaml** — All recurring compliance obligations
+
+# Agents
+
+## schema-reviewer
+
+You are a reviewer focused on YAML schema consistency and cross-reference integrity in the compliance data files.
+
+**Your focus:** Verify that compliance YAML files maintain consistent schemas and valid cross-references.
+
+**What to check:**
+
+1. **Schema consistency** across `compliance/decisions/*.yaml`:
+   - All entries in a file use the same field names and structure
+   - Required fields are present (id, status, description at minimum)
+   - Date fields use consistent format (YYYY-MM-DD)
+   - Status values are from a consistent set (not mixing "open"/"active"/"pending" arbitrarily)
+
+2. **Cross-references** between compliance files:
+   - Finding IDs referenced in decisions match entries in `ssp-review-findings.md`
+   - Calendar entries reference valid obligation sources
+   - Delegation tracker references valid party names consistently
+
+3. **Calendar accuracy** in `compliance/calendar/recurring.yaml`:
+   - Recurrence patterns are valid (monthly, quarterly, annual, etc.)
+   - No impossible dates (Feb 30, etc.)
+   - Frequency and description are consistent
+
+**Flag issues if:**
+- A YAML file has entries with inconsistent field names (e.g., some use `finding_id`, others use `findingId`)
+- A cross-reference points to an ID that doesn't exist in the target file
+- Calendar dates are invalid or recurrence patterns are malformed
+- Required fields are missing from new entries
+
+**Do NOT flag:**
+- Content accuracy of compliance decisions (humans own those decisions)
+- Style preferences in YAML formatting or field ordering
+- Pre-existing schema inconsistencies not introduced by this PR
+
+## credbridge-reviewer
+
+You are a reviewer focused on the Go credbridge binary and its integration points.
+
+**Your focus:** Verify that credbridge changes are correct and won't break downstream consumers.
+
+**What to check:**
+
+1. **AWS SDK usage**:
+   - Credential chain is correctly configured
+   - ECR token handling (base64 encoding/decoding, expiration parsing)
+   - Region configuration is correct for GovCloud
+   - Error handling covers all AWS API failure modes
+
+2. **Downstream impact**:
+   - credbridge is built into every VE container image via `image-*` repos
+   - Changes to CLI interface, exit codes, or output format break consumers
+   - Changes to the credential refresh loop affect all running containers
+
+3. **Go module health**:
+   - `go.mod` and `go.sum` are consistent
+   - The `replace` directive for the local sub-module is preserved
+   - Dependency versions are appropriate
+
+**Flag issues if:**
+- AWS credential chain order is wrong (could cause auth failures in GovCloud)
+- ECR token parsing changes could produce invalid Docker credentials
+- CLI interface changes break backward compatibility
+- Error handling is missing for AWS API calls that can fail
+
+**Do NOT flag:**
+- The `replace` directive in `go.mod` (intentional local sub-module)
+- GovCloud-specific region hardcoding (intentional)
+- Style or formatting preferences
+
+## workflow-reviewer
+
+You are a reviewer focused on GitHub Actions workflow correctness and security.
+
+**Your focus:** Verify that workflow changes are correct, secure, and follow VE conventions.
+
+**What to check:**
+
+1. **Action versions**:
+   - Actions use specific versions (not `@main` or `@latest`)
+   - Version references are consistent across workflows
+
+2. **Secrets and permissions**:
+   - Referenced secrets exist at org or repo level
+   - Permissions are minimally scoped (not overly broad)
+   - No secrets leaked in logs or outputs
+
+3. **Trigger configuration**:
+   - Triggers match the intended automation purpose
+   - Branch filters are correct
+   - Event types are appropriate
+
+4. **Credential rotation config** (`.github/credential-rotations.yml`):
+   - Date format is YYYY-MM-DD
+   - Required fields present (name, expires, rotation_steps, description)
+   - Expiry dates are in the future (or flagged as overdue)
+
+**Flag issues if:**
+- An action version is unpinned or uses a mutable tag
+- Permissions are broader than necessary
+- Secret references don't match documented org secrets
+- Credential rotation entries have invalid date formats
+
+**Do NOT flag:**
+- The use of `CLAUDE_CODE_OAUTH_TOKEN` secret (standard across all VE repos)
+- Org-level secrets like `JIRA_API_TOKEN` and `SG_API_KEY` (documented in CLAUDE.md)
+- Style preferences in YAML formatting

--- a/AGENT-REVIEWERS.md
+++ b/AGENT-REVIEWERS.md
@@ -58,7 +58,7 @@ You are a reviewer focused on GitHub Actions workflow correctness and security.
 **What to check:**
 
 1. **Action versions**:
-   - Actions are pinned to commit SHAs with a version comment (e.g., `@abc123 # v1.2.3`) — this is the VE standard; floating tags like `@v1`, `@main`, or `@latest` are not acceptable
+   - Actions are pinned to commit SHAs with a version comment (e.g., actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4) — this is the VE standard; floating tags like @v1, @main, or @latest are not acceptable
    - SHA pins are consistent across workflows (same action should use the same SHA everywhere)
 
 2. **Secrets and permissions**:

--- a/AGENT-REVIEWERS.md
+++ b/AGENT-REVIEWERS.md
@@ -4,7 +4,6 @@ This is a mixed-language operational tooling and compliance data repository. Whe
 
 - Python code (`vetools/`, `bin/`) uses Click for CLI and kubernetes-client for K8s interaction
 - Go code (`credbridge/`) provides ECR credential bridging built into every VE container image
-- Compliance YAML (`compliance/`) stores human decisions — scanner data stays in source systems
 - GitHub Actions workflows handle credential rotation reminders and code review automation
 - The `replace` directive in `go.mod` is intentional — `credbridge/` is a local sub-module
 - Hardcoded AWS GovCloud regions and account IDs in compliance docs are intentional
@@ -12,9 +11,6 @@ This is a mixed-language operational tooling and compliance data repository. Whe
 # Context
 
 - **CLAUDE.md** — Repository structure, commands, environment context, cross-repo references
-- **compliance/DESIGN.md** — Compliance OS architecture, data model, and vision
-- **compliance/ssp-review-findings.md** — Authoritative SSP findings list (264 findings, 9 themes)
-- **compliance/calendar/recurring.yaml** — All recurring compliance obligations
 
 # Agents
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,8 +31,7 @@ cd credbridge && go build -o ../build/credbridge .
 - `scratch/` — Gitignored working directory for local experiments
 
 ### Compliance Operating System
-Compliance data has moved to the dedicated [ve-compliance](https://github.com/Valid-Eval/ve-compliance) repo.
-The `compliance/` directory in this repo is a stale artifact from feature branch work (PR #3, closed without merging) and should be ignored.
+Compliance data lives in the dedicated [ve-compliance](https://github.com/Valid-Eval/ve-compliance) repo.
 
 ## Environment Context
 
@@ -51,7 +50,7 @@ The `compliance/` directory in this repo is a stale artifact from feature branch
 - **ve-app**: Main application repository
 - **ve-zarf**: Air-gap packaging, Zarf bundles, container image fleet doc
 - **ve-iac**: OpenTofu IaC for IL2 stg/prod
-- **ve-deployments**: Flux/Helm configs for CI cluster (branch: `ve-com-testing-v2`)
+- **ve-deployments**: Flux/Helm configs for CI cluster
 - **infosec-iac**: FedRAMP compliance automation, Graylog, security tooling
 - **valid-eval-skills**: Claude Code skills including supply-chain-assessment
 - **image-***: 12 container image build repos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# ve-tools
+
+Operational tooling and compliance data for Valid Eval.
+
+## Commands
+
+```bash
+# Python package (kubectl plugins)
+pip install -e .                     # Install vetools + kubectl plugins
+kubectl ve-console                   # Interactive k8s console
+kubectl ve-queues                    # List Redis queues
+kubectl ve-queue <name>              # Inspect a specific queue
+
+# Go binary (ECR credential bridging)
+cd credbridge && go build -o ../build/credbridge .
+
+# Credential rotation workflow
+# Runs daily at 9 AM UTC via GitHub Actions
+# Configure credentials in .github/credential-rotations.yml
+# After rotating: update expires date, close GH issue + Jira ticket
+```
+
+## Repository Structure
+
+### Operational Tooling
+- `vetools/` — Python package (click CLI, kubernetes client, PyRSMQ). Requires Python 3.x.
+- `credbridge/` — Go 1.22+ binary for AWS ECR credential bridging in containers
+- `bin/` — kubectl plugins (`kubectl-ve-console`, `kubectl-ve-queue`, `kubectl-ve-queues`, `dockercredrot`)
+- `.github/workflows/credential-rotation-reminder.yml` — Daily credential expiry checks → GH issues + Jira + email
+- `.github/credential-rotations.yml` — Credential inventory with expiry dates and rotation steps
+- `scratch/` — Gitignored working directory for local experiments
+
+### Compliance Operating System
+Compliance data has moved to the dedicated [ve-compliance](https://github.com/Valid-Eval/ve-compliance) repo.
+The `compliance/` directory in this repo is a stale artifact from feature branch work (PR #3, closed without merging) and should be ignored.
+
+## Environment Context
+
+- **VE Authorization**: FedRAMP Ready (FR2514747735), NASA Agency ATO
+- **Infrastructure**: AWS GovCloud, EKS, UDS Core (Defense Unicorns)
+- **Container images**: RapidFort hardened base images
+- **Runtime security**: Falco (replaced NeuVector in UDS v0.56)
+- **SIEM**: Graylog (InfusionPoints SOC)
+- **SAST**: SonarQube (upgrade to current LTA is urgent — A-15)
+- **Scanning**: AWS Inspector, Grype (ve-zarf CI), Dependabot (GitHub)
+- **IaC**: OpenTofu (formerly Terraform)
+- **GitOps**: Flux, Zarf, Helm
+
+## Cross-Repo References
+
+- **ve-app**: Main application repository
+- **ve-zarf**: Air-gap packaging, Zarf bundles, container image fleet doc
+- **ve-iac**: OpenTofu IaC for IL2 stg/prod
+- **ve-deployments**: Flux/Helm configs for CI cluster (branch: `ve-com-testing-v2`)
+- **infosec-iac**: FedRAMP compliance automation, Graylog, security tooling
+- **valid-eval-skills**: Claude Code skills including supply-chain-assessment
+- **image-***: 12 container image build repos
+
+## Gotchas
+
+- **credbridge is built into every VE container image** — it provides ECR auth at runtime. Changes here affect all image-* repos.
+- **Credential rotation workflow** uses org-level secrets (JIRA_API_TOKEN, SG_API_KEY) — test with `dry_run: true` workflow dispatch.
+- **Go module uses `replace` directive** — `credbridge/` is a local sub-module, not a separate repo.

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    "helpers:pinGitHubActionDigestsToSemver"
+  ],
+  "labels": ["renovate"],
+  "minimumReleaseAge": "7 days",
+  "internalChecksFilter": "strict",
+  "schedule": ["after 6am on sunday"],
+  "prHourlyLimit": 1,
+  "prConcurrentLimit": 3,
+  "ignorePaths": [
+    "scratch/**"
+  ],
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions SHA pinning and updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "commitMessageTopic": "github-actions"
+    },
+    {
+      "description": "Group Go module updates for credbridge",
+      "matchManagers": ["gomod"],
+      "groupName": "Go Modules",
+      "commitMessageTopic": "go-modules"
+    },
+    {
+      "description": "Require dashboard approval for major updates",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true,
+      "addLabels": ["major-update"]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Three-layer automated code review for ve-tools, adapted from patterns in ve-app,
ve-zarf, ve-iac, and infosec-iac but tailored to this repo's content mix.

## What's Added

- **`.github/workflows/claude-code-review.yml`** — Automated inline PR comments on push.
  Review prompt covers Python, Go, compliance YAML, GitHub Actions, and markdown.
  Skips renovate[bot] PRs. Posts line-level comments (not bundled PR comments).

- **`.github/workflows/claude.yml`** — Interactive @claude mention support in issues/PRs.

- **`.gemini/config.yaml` + `.gemini/styleguide.md`** — Gemini Code Assist config with
  ve-tools-specific style guide and false-positive exclusions.

- **`AGENT-REVIEWERS.md`** — Two focused agent reviewers for pr-review-loop:
  - `credbridge-reviewer`: Go binary correctness and downstream impact
  - `workflow-reviewer`: GitHub Actions correctness and security

- **`CLAUDE.md`** — Repository context for AI tools (structure, commands, environment, cross-repo refs)

- **`renovate.json`** — Renovate dependency update config (7-day minimum release age, Sunday schedule, grouped updates for GitHub Actions and Go modules)

## Key Design Choices

- **Line-level comments** throughout — not single bundled PR comments
- **Test coverage flagging enabled** — reviewer will note missing tests to keep
  accountability for building test infrastructure
- **credbridge impact awareness** — reviewer knows it's built into every VE container

## Prerequisites

- `CLAUDE_CODE_OAUTH_TOKEN` org secret must be configured
- Gemini Code Assist GitHub app must be installed on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)