### PR TITLE
fix: update kubectl-ve-queue(s) pod lookup for redis->valkey rename

### DIFF
--- a/bin/kubectl-ve-queue
+++ b/bin/kubectl-ve-queue
@@ -66,9 +66,6 @@ def get_queue_item(redis_host, redis_port, queue, item):
 def exec_queue_item_read(core_v1, context, queue, item, output, verbose, pod_name):
     pod = get_a_pod(core_v1, context, pod_name)
     if not pod:
-        sys.stderr.write(f"No pod from {queue} in {context['namespace']}\n")
-        sys.exit(1)
-    if not pod:
         sys.stderr.write(f"No pod from {pod_name} in {context['namespace']}\n")
         sys.exit(1)
 
@@ -98,9 +95,6 @@ def exec_queue_item_read(core_v1, context, queue, item, output, verbose, pod_nam
 
 def exec_queue_read(core_v1, context, queue, output, verbose, pod_name):
     pod = get_a_pod(core_v1, context, pod_name)
-    if not pod:
-        sys.stderr.write(f"No pod from {queue} in {context['namespace']}\n")
-        sys.exit(1)
     if not pod:
         sys.stderr.write(f"No pod from {pod_name} in {context['namespace']}\n")
         sys.exit(1)

--- a/bin/kubectl-ve-queue
+++ b/bin/kubectl-ve-queue
@@ -63,13 +63,13 @@ def get_queue_item(redis_host, redis_port, queue, item):
     return data
 
 
-def exec_queue_item_read(core_v1, context, queue, item, output, verbose):
-    pod = get_a_pod(core_v1, context, "valid-eval-redis")
+def exec_queue_item_read(core_v1, context, queue, item, output, verbose, pod_name):
+    pod = get_a_pod(core_v1, context, pod_name)
     if not pod:
         sys.stderr.write(f"No pod from {queue} in {context['namespace']}\n")
         sys.exit(1)
     if not pod:
-        sys.stderr.write(f"No pod from valid-eval-redis in {context['namespace']}\n")
+        sys.stderr.write(f"No pod from {pod_name} in {context['namespace']}\n")
         sys.exit(1)
 
     port = find_free_port()
@@ -96,13 +96,13 @@ def exec_queue_item_read(core_v1, context, queue, item, output, verbose):
     finally:
         p.join()
 
-def exec_queue_read(core_v1, context, queue, output, verbose):
-    pod = get_a_pod(core_v1, context, "valid-eval-redis")
+def exec_queue_read(core_v1, context, queue, output, verbose, pod_name):
+    pod = get_a_pod(core_v1, context, pod_name)
     if not pod:
         sys.stderr.write(f"No pod from {queue} in {context['namespace']}\n")
         sys.exit(1)
     if not pod:
-        sys.stderr.write(f"No pod from valid-eval-redis in {context['namespace']}\n")
+        sys.stderr.write(f"No pod from {pod_name} in {context['namespace']}\n")
         sys.exit(1)
 
     port = find_free_port()
@@ -135,7 +135,8 @@ def exec_queue_read(core_v1, context, queue, output, verbose):
 @click.option('--namespace','-n', help='Namespace')
 @click.option('--output','-o', default="text", help='Output (one of text, json, yaml)')
 @click.option('--verbose','-v', is_flag=True, default=False, help='Verbose')
-def main(queue, item, namespace, output, verbose):
+@click.option('--pod-name', envvar='VE_QUEUE_POD_NAME', default='valid-eval-valkey', help='Pod name prefix to look up (env: VE_QUEUE_POD_NAME)')
+def main(queue, item, namespace, output, verbose, pod_name):
     config.load_kube_config()
     try:
         c = Configuration().get_default_copy()
@@ -148,9 +149,9 @@ def main(queue, item, namespace, output, verbose):
     if namespace:
         context["namespace"] = namespace
     if item:
-        exec_queue_item_read(core_v1, context, queue, item, output, verbose)
-    else: 
-        exec_queue_read(core_v1, context, queue, output, verbose)
+        exec_queue_item_read(core_v1, context, queue, item, output, verbose, pod_name)
+    else:
+        exec_queue_read(core_v1, context, queue, output, verbose, pod_name)
 
 if __name__ == '__main__':
     main()

--- a/bin/kubectl-ve-queues
+++ b/bin/kubectl-ve-queues
@@ -29,10 +29,10 @@ def get_metrics(redis_host, redis_port):
     return metrics
 
 
-def exec_queue(v1, context, output, verbose):
-    pod = get_a_pod(v1, context, "valid-eval-redis")
+def exec_queue(v1, context, output, verbose, pod_name):
+    pod = get_a_pod(v1, context, pod_name)
     if not pod:
-        sys.stderr.write(f"No pod from valid-eval-redis in {context['namespace']}\n")
+        sys.stderr.write(f"No pod from {pod_name} in {context['namespace']}\n")
         sys.exit(1)
 
     port = find_free_port()
@@ -165,7 +165,8 @@ def print_table(metrics):
 @click.option('--namespace','-n', help='Namespace')
 @click.option('--output','-o', default="text", help='Output (one of text, json, yaml)')
 @click.option('--verbose','-v', is_flag=True, default=False, help='Verbose')
-def main(namespace, output, verbose):
+@click.option('--pod-name', envvar='VE_QUEUE_POD_NAME', default='valid-eval-valkey', help='Pod name prefix to look up (env: VE_QUEUE_POD_NAME)')
+def main(namespace, output, verbose, pod_name):
     config.load_kube_config()
     try:
         c = Configuration().get_default_copy()
@@ -177,7 +178,7 @@ def main(namespace, output, verbose):
     context = config.list_kube_config_contexts()[1]['context']
     if namespace:
         context["namespace"] = namespace
-    exec_queue(core_v1, context, output, verbose)
+    exec_queue(core_v1, context, output, verbose, pod_name)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Summary
- The Chainguard migration renamed the `valid-eval-redis` pod to `valid-eval-valkey`, which broke `kubectl ve-queue`/`kubectl ve-queues`' hardcoded pod-name lookup (found live while checking `redis-queue-exporter` after the v8.39 prod deploy).
- Updated all 6 hardcoded `"valid-eval-redis"` references in `bin/kubectl-ve-queue` and `bin/kubectl-ve-queues` to `"valid-eval-valkey"`.
- Added a `--pod-name` flag (and `VE_QUEUE_POD_NAME` env var) to both scripts, defaulting to `valid-eval-valkey`, so future pod renames are a config change instead of a code change.

## Test plan
- [x] `python3 -m py_compile` on both scripts
- [x] `pip install -e .` in a scratch venv, ran `--help` on both scripts — confirms `--pod-name` option and env-var hint render correctly
- [x] Introspected the click `Command` object to confirm `default='valid-eval-valkey'` and `envvar='VE_QUEUE_POD_NAME'` are wired correctly
- [x] Live cluster verification (pod lookup + port-forward against a real `valid-eval-valkey` pod) — not possible in the sandbox this was developed in; needs a real kubeconfig/cluster context before merge.