### PR TITLE
[VEP-1977] Add RAILS_SECRET_KEY_BASE rotation tracking

### DIFF
--- a/.github/credential-rotations.yml
+++ b/.github/credential-rotations.yml
@@ -66,8 +66,8 @@ credentials:
          account (staging: il2 staging acct; prod: il2 prod acct) with the new value
          (key: SECRET_KEY_BASE). Exact secret names per INF-137 / ve-iac PR #215 ESO setup.
       3. Wait for / force the ESO ExternalSecret sync, then restart the Rails
-         deployments (list them first: `kubectl -n valid-eval get deploy | grep backend`):
-         `kubectl -n valid-eval rollout restart deploy <backend-api> <backend-admin> <backend-integration> <backend-worker> <worker-tag-matching>`
+         deployments: `kubectl get deployment -n valid-eval -o name | grep backend |
+         xargs kubectl -n valid-eval rollout restart`
          (do NOT use `-l app=ValidEval` — that label is chart-wide and would also
          restart non-Rails components)
       4. Verify per env: `kubectl exec` a backend pod →

--- a/.github/credential-rotations.yml
+++ b/.github/credential-rotations.yml
@@ -53,3 +53,33 @@ credentials:
       - The email secret does not need rotation — only the token
       - If this token is already expired, the Jira notification step for OTHER
         credentials will also fail — rotate this one first
+
+  - name: RAILS_SECRET_KEY_BASE
+    description: Rails secret_key_base for ve-app backend (signs session cookies + HS256 JWTs) — unique per environment (staging + prod), stored in AWS Secrets Manager, ESO-synced into the cluster
+    expires: "2026-08-15"
+    remind_days_before: 15
+    jira_priority: Highest
+    rotation_steps: |-
+      1. Generate a fresh 128-char hex value PER ENVIRONMENT (staging and prod must
+         differ): `openssl rand -hex 64`
+      2. Update the AWS Secrets Manager secret `<app-ns>/secret-key-base` in each
+         account (staging: il2 staging acct; prod: il2 prod acct) with the new value
+         (key: SECRET_KEY_BASE). Exact secret names per INF-137 / ve-iac PR #215 ESO setup.
+      3. Wait for / force the ESO ExternalSecret sync, then restart the Rails
+         deployments (list them first: `kubectl -n valid-eval get deploy | grep backend`):
+         `kubectl -n valid-eval rollout restart deploy <backend-api> <backend-admin> <backend-integration> <backend-worker> <worker-tag-matching>`
+         (do NOT use `-l app=ValidEval` — that label is chart-wide and would also
+         restart non-Rails components)
+      4. Verify per env: `kubectl exec` a backend pod →
+         `bin/rails runner 'puts Rails.application.secret_key_base[0,6]'` matches the
+         Secrets Manager value prefix, and interactive login works.
+      5. NOTE: rotation invalidates ALL active sessions and outstanding JWTs — schedule
+         in a maintenance window / off-hours and give users notice.
+    notes: |-
+      - Origin: Dark Wolf July 2026 pen test §4.2 (F-PT-2), Jira VEP-1977 (app fix) +
+        INF-137 (ESO/ASM infra half). Committed fallback keys (in git history since
+        2025-01-29) are permanently burned — never reuse them.
+      - First rotation MUST complete by 2026-08-15 (Rule4 POA&M committed date) and is
+        sequenced with merging the VEP-1977 ve-app PR (chart requires the ESO secret
+        when railsEnv=production; app fails closed without SECRET_KEY_BASE).
+      - Rotation does NOT require any ve-app code/chart change once VEP-1977 is merged —

--- a/.github/credential-rotations.yml
+++ b/.github/credential-rotations.yml
@@ -83,3 +83,5 @@ credentials:
         sequenced with merging the VEP-1977 ve-app PR (chart requires the ESO secret
         when railsEnv=production; app fails closed without SECRET_KEY_BASE).
       - Rotation does NOT require any ve-app code/chart change once VEP-1977 is merged —
+        it is purely ASM update + pod restart (that property is by design).
+      - Subsequent cadence: annual (bump `expires` +12 months after each rotation).


### PR DESCRIPTION
Adds rotation tracking for the Rails secret_key_base as it moves to AWS Secrets Manager (per-environment, ESO-synced) under VEP-1977/INF-137. The 2026-08-15 expires date is the POA&M-committed deadline for the initial rotation retiring the burned fallback keys; cadence is annual thereafter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF)"