### PR TITLE
[VEP-2018] chore: bump RAILS_SECRET_KEY_BASE expires after completed rotation

### DIFF
--- a/.github/credential-rotations.yml
+++ b/.github/credential-rotations.yml
@@ -56,7 +56,7 @@ credentials:
 
   - name: RAILS_SECRET_KEY_BASE
     description: Rails secret_key_base for ve-app backend (signs session cookies + HS256 JWTs) — unique per environment (staging + prod), stored in AWS Secrets Manager, ESO-synced into the cluster
-    expires: "2026-08-15"
+    expires: "2027-08-05"
     remind_days_before: 15
     jira_priority: Highest
     rotation_steps: |-


### PR DESCRIPTION
## Summary
- RAILS_SECRET_KEY_BASE rotation completed 2026-08-05 (VEP-2032/VEP-2018), but `expires` in `credential-rotations.yml` was never bumped.
- That gap is why the daily reminder cron fired a duplicate ticket (VEP-2032) days after the original (VEP-2018) — the dedup logic only suppresses when an *open* GH issue with a matching title exists; closing the issue without updating `expires` re-opens the reminder window on the very next run.
- Bumped to 2027-08-05 (annual cadence from actual rotation date, per the entry's own documented convention).

## Note for a follow-up (not in this PR — scoping only)
This is a design gap worth hardening: nothing currently verifies `expires` was actually updated before/when the tracking issue is closed. A future improvement could have the reminder workflow check, on issue-close, whether `expires` moved forward — if not, comment or reopen rather than silently going quiet until the next duplicate fires. Tracking this as a v8.41-adjacent tooling item rather than bundling untested new CI logic into this rotation-completion PR.

## Test plan
- [ ] Confirm `credential-rotations.yml` still validates (the `validate` job in `credential-rotation-reminder.yml` runs on any PR touching this file).